### PR TITLE
Rename CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 ---
-name: CI
+name: Build
 
 on: push
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Home Manager Configuration
 
-[![CI](https://github.com/sestrella/home-manager.config/actions/workflows/main.yml/badge.svg)](https://github.com/sestrella/home-manager.config/actions/workflows/main.yml)
+[![Build](https://github.com/sestrella/home-manager.config/actions/workflows/build.yml/badge.svg)](https://github.com/sestrella/home-manager.config/actions/workflows/build.yml)
 
 My [Home Manager](https://github.com/nix-community/home-manager) configuration.
 


### PR DESCRIPTION
This pull request includes changes to rename the CI workflow file and update its references. The most important changes involve renaming `.github/workflows/main.yml` to `.github/workflows/build.yml` and updating the badge link in the `README.md` to reflect the new file name.

Workflow file renaming:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L2-R2): Renamed from `.github/workflows/main.yml` and updated the workflow name from "CI" to "Build."

Badge link update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the badge link to reference the renamed workflow file (`build.yml`) instead of the old file (`main.yml`).