### PR TITLE
ci: Add check job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
         run: nix profile install nixpkgs#devenv
       - name: Run tests
         run: devenv test
+        env:
+          SECRETSPEC_PROVIDER: env
 
   build:
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,15 +8,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: macos-latest
+  check:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
-      - name: Check flake.lock
-        uses: DeterminateSystems/flake-checker-action@v9
+        uses: cachix/install-nix-action@v31
+      - name: Install devenv
+        run: nix profile install nixpkgs#devenv
+      - name: Run tests
+        run: devenv test
+
+  build:
+    runs-on: macos-latest
+    needs: [check]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
       - name: Setup Cachix
         uses: cachix/cachix-action@v15
         with:
@@ -24,4 +35,4 @@ jobs:
           extraPullNames: devenv
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build configuration
-        run: nix run home-manager/release-24.11 -- build --flake ${{ github.workspace }}
+        run: nix run home-manager/master -- build --flake ${{ github.workspace }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
       - name: Install devenv
-        run: nix profile install nixpkgs#devenv
+        run: nix profile add nixpkgs#devenv
       - name: Run tests
         run: devenv test
         env:
@@ -30,11 +30,11 @@ jobs:
         uses: actions/checkout@v5
       - name: Install Nix
         uses: cachix/install-nix-action@v31
-      # - name: Setup Cachix
-      #   uses: cachix/cachix-action@v15
-      #   with:
-      #     name: sestrella
-      #     extraPullNames: devenv
-      #     authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v15
+        with:
+          name: sestrella
+          extraPullNames: devenv
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build configuration
         run: nix run home-manager/master -- build --flake ${{ github.workspace }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
   build:
     runs-on: macos-latest
     needs: [check]
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,11 @@ jobs:
         uses: actions/checkout@v5
       - name: Install Nix
         uses: cachix/install-nix-action@v31
-      - name: Setup Cachix
-        uses: cachix/cachix-action@v15
-        with:
-          name: sestrella
-          extraPullNames: devenv
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      # - name: Setup Cachix
+      #   uses: cachix/cachix-action@v15
+      #   with:
+      #     name: sestrella
+      #     extraPullNames: devenv
+      #     authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build configuration
         run: nix run home-manager/master -- build --flake ${{ github.workspace }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2020-2022 Sebastián Estrella
+Copyright 2020-present Sebastián Estrella
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
The build workflow has been updated to include a new `check` job that runs tests using `devenv`. This ensures that the codebase is tested before proceeding with the build.

Additionally, the build job has been updated to use the `master` branch of `home-manager` for building the configuration, replacing the previous `release-24.11` branch. This allows for incorporating the latest changes and improvements.

The `checkout` and `install-nix-action` versions have also been updated to their latest releases (`v5` and `v31` respectively) to ensure compatibility and leverage the newest features.

autocommitmsg(model=gemini-2.5-flash-lite,response_time=1.717753834s,execution_time=1.7269535s)
